### PR TITLE
Fix docs build for release tags

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,37 +1,42 @@
 name: Documentation
+
+permissions:
+  contents: write
+  pages: write
+
 on:
-  workflow_dispatch:
   push:
     branches:
-      - main
+      - 'master'
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
-  docs:
-    name: Build and deploy documentation
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: write
-      pull-requests: read
-      statuses: write
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version:
+          - '1' # automatically expands to the latest stable 1.x release of Julia
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
     steps:
       - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v3
+      - uses: julia-actions/setup-julia@latest
         with:
-          version: '1'
-      - uses: julia-actions/cache@v3
-      - name: Install docs dependencies
-        run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
         run: julia --project=docs docs/make.jl


### PR DESCRIPTION
I noticed that the stable docs link is dead, since apparently the docs build didn't trigger on the latest release tag. I think I remember running into this elsewhere, and this turned out to be some issues with the permissions.

I updated the workflow file to essentially mimic that of MPSKit.jl. The key difference is the `pages: write` permission which is now added, which hopefully solves the issue.